### PR TITLE
extractMoreauBroto return NA's when nlag is greater than the length of the sequence, fixes #2

### DIFF
--- a/R/desc04MoreauBroto.R
+++ b/R/desc04MoreauBroto.R
@@ -109,9 +109,7 @@ extractMoreauBroto = function (x, props = c('CIDH920105', 'BHAR880101',
   if (protcheck(x) == FALSE) stop('x has unrecognized amino acid type')
   
   if (nchar(x) <= nlag){
-    # Cap nlag
-    nlag <- nchar(x) - 1
-    warning("extractMoreauBroto: The length of the sequence is <= nlag; nlag has been set to ", nlag, '.')
+    warning("extractMoreauBroto: The length of the sequence is <= nlag; NA's will result.")
   }
 
   # 1. Compute Pr values for each type of property
@@ -154,7 +152,9 @@ extractMoreauBroto = function (x, props = c('CIDH920105', 'BHAR880101',
   
   for (i in 1:n) {
     for (j in 1:nlag) {
-      MB[[i]][j] = sum(P[[i]][1:(N - j)] * P[[i]][(1:(N - j)) + j])/(N - j)
+      MB[[i]][j] = ifelse(N-j > 0,
+                          sum(P[[i]][1:(N - j)] * P[[i]][(1:(N - j)) + j])/(N - j),
+                          NA)
     }
   }
   

--- a/R/desc04MoreauBroto.R
+++ b/R/desc04MoreauBroto.R
@@ -108,6 +108,12 @@ extractMoreauBroto = function (x, props = c('CIDH920105', 'BHAR880101',
   
   if (protcheck(x) == FALSE) stop('x has unrecognized amino acid type')
   
+  if (nchar(x) <= nlag){
+    # Cap nlag
+    nlag <- nchar(x) - 1
+    warning("extractMoreauBroto: The length of the sequence is <= nlag; nlag has been set to ", nlag, '.')
+  }
+
   # 1. Compute Pr values for each type of property
   
   AAidx = read.csv(system.file('sysdata/AAidx.csv', package = 'protr'), header = TRUE)


### PR DESCRIPTION
I changed `extractMoreauBroto()` to return NA's for every lag >= nchar(x) and issue a warning when the length of the sequence, `nchar(x)`, is less than or equal to `nlag`.
Fixes #2