### PR TITLE
extractQSO: Also stop with an error if the length of the sequence is equal to nlag

### DIFF
--- a/R/desc12QSO.R
+++ b/R/desc12QSO.R
@@ -49,7 +49,7 @@ extractQSO = function (x, nlag = 30, w = 0.1) {
   if (protcheck(x) == FALSE) stop('x has unrecognized amino acid type')
   
   N = nchar(x)
-  if (N < nlag) stop("Length of the protein sequence must be no less than 'nlag'")
+  if (N <= nlag) stop("Length of the protein sequence must be greater than 'nlag'")
   
   DistMat1 = read.csv(system.file('sysdata/Schneider-Wrede.csv', package = 'protr'), header = TRUE)
   DistMat2 = read.csv(system.file('sysdata/Grantham.csv', package = 'protr'), header = TRUE)


### PR DESCRIPTION
Fixes #13.