### PR TITLE
extractCTDT: Return correct results when a transition has a count of zero

### DIFF
--- a/R/desc08CTDT.R
+++ b/R/desc08CTDT.R
@@ -87,7 +87,7 @@ extractCTDT = function (x) {
   # Combine single amino acids by a 2-length step
   
   for (i in 1:7) G[[i]] = paste(G[[i]][-n], G[[i]][-1], sep = '')
-  G = lapply(G, as.factor)
+  G = lapply(G, function(x) factor(x, levels=c('G1G2', 'G2G1', 'G1G3', 'G3G1', 'G2G3', 'G3G2', 'G1G1', 'G2G2', 'G3G3')))
   
   GSummary = lapply(G, summary)
   


### PR DESCRIPTION
Added all levels to the factor so that transitions that are not in the sequence get a (correct) count of zero instead of `NA`.
This is not the prettiest solution but it works.
Fixes road2stat/protr#19.