### PR TITLE
Release protr 1.7-5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: protr
-Version: 1.7-4
+Version: 1.7-5
 Title: Generating Various Numerical Representation Schemes for Protein Sequences
 Description: Comprehensive toolkit for generating various numerical
     features of protein sequences described in Xiao et al. (2015)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# protr 1.7-5
+
+## Maintenance
+
+- Remove named comment for non-ORCID/ROR identifiers in `DESCRIPTION` to avoid
+  `R CMD check` note reported only in Debian r-devel environments (#60).
+
 # protr 1.7-4
 
 ## Improvements

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Downloads from the RStudio CRAN mirror](https://cranlogs.r-pkg.org/badges/protr)](https://cranlogs.r-pkg.org/badges/protr)
 <!-- badges: end -->
 
-Comprehensive toolkit for generating various numerical features of protein sequences described in Xiao et al. (2015) <[DOI:10.1093/bioinformatics/btv042](https://doi.org/10.1093/bioinformatics/btv042)> ([PDF](https://nanx.me/papers/protr.pdf)).
+Comprehensive toolkit for generating various numerical features of protein sequences described in Xiao et al. (2015) ([PDF](https://nanx.me/papers/protr.pdf)).
 
 ## Paper citation
 


### PR DESCRIPTION
This PR bumps the version number to 1.7-5 and updates the changelog.

Also removed a DOI link that generates HTTP 403 errors locally when checked.